### PR TITLE
Force dataType to xml

### DIFF
--- a/votable.js
+++ b/votable.js
@@ -118,7 +118,7 @@ function Parser() {
         var time = new Date().getTime()
         var asyncmode = false;
         if (thisParser.callbackfn != null) asyncmode = true;
-        $.ajaxSetup({async: asyncmode});
+        $.ajaxSetup({async: asyncmode, dataType: 'xml'});
 
         $.get(xmlDoc, function(DataXmlDoc) {
                 var i = 0, benchmark;


### PR DESCRIPTION
Current version of the parser does not work if the server outputs a mime-type not related to XML (eg text/plain)
Fixing the dataType to 'xml' fixes this issue
